### PR TITLE
Update readme to match function of registry-proxy

### DIFF
--- a/cluster/addons/registry/README.md
+++ b/cluster/addons/registry/README.md
@@ -198,11 +198,9 @@ spec:
       value: kube-registry.kube-system.svc.cluster.local
     - name: REGISTRY_PORT
       value: "5000"
-    - name: FORWARD_PORT
-      value: "5000"
     ports:
     - name: registry
-      containerPort: 5000
+      containerPort: 80
       hostPort: 5000
 ```
 <!-- END MUNGE: EXAMPLE ../../saltbase/salt/kube-registry-proxy/kube-registry-proxy.yaml -->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
There was a change to the registry-proxy but the documentaiton wasn't comply updated to reflect change made.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
[contribute deis/registry-proxy as a replacement for kube-registry-proxy](https://github.com/kubernetes/kubernetes/pull/35797) 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

Updated kube-registry-proxy example to match functionality.